### PR TITLE
Links fixed

### DIFF
--- a/cursos/docker-images/01_creacion_de_imaxes/06_mellorando_o_dockerfile_de_web_gatinho_do_dia.md
+++ b/cursos/docker-images/01_creacion_de_imaxes/06_mellorando_o_dockerfile_de_web_gatinho_do_dia.md
@@ -1,7 +1,7 @@
 # Mellorando o Dockerfile da web "gatiño do día"
 
 ## 1. Alixeirando a imaxe
-Se construímo-la imaxe do gatinho web da actividade anterior, podemos sabe-lo tamaño da mesma.
+Se construímo-la imaxe do gatinho web da [actividade anterior](https://prefapp.github.io/formacion/cursos/docker-images/#/./01_creacion_de_imaxes/05_o_dockerfile_construindo_a_imaxe_do_gatinho_do_dia), podemos sabe-lo tamaño da mesma.
 
 Basta con facer:
 

--- a/cursos/docker/00_actividades/01_modulo_1.md
+++ b/cursos/docker/00_actividades/01_modulo_1.md
@@ -2,7 +2,7 @@
 
 ## Comprender e empregar a tecnoloxía de namespaces
 
-> Os [namespaces](https://prefapp.github.io/formacion/docker/#/01_que_e_un_contedor_de_software/08_namespaces_en_profundidade) son un dos pilares básicos para a construcción de contedores, a posibilidade de crear "vistas" privadas so SO para un proceso ou conxunto de procesos aporta unha flexibilidade moi grande para a execución de procesos.
+> Os [namespaces](https://prefapp.github.io/formacion/cursos/docker/#/./01_que_e_un_contedor_de_software/08_namespaces_en_profundidade) son un dos pilares básicos para a construcción de contedores, a posibilidade de crear "vistas" privadas so SO para un proceso ou conxunto de procesos aporta unha flexibilidade moi grande para a execución de procesos.
 
 Antes de realizar a tarefa le atentamente as **instrucións**, os **indicadores de logro** e os **criterios de corrección** que de seguido se detallan.
 
@@ -64,7 +64,7 @@ Antes de realizar a tarefa le atentamente as **instrucións**, os **indicadores 
 
 Pasos:
 
-1. **Consultar** e **analizar** a documentación sobre [cgroups: grupos de control de procesos](https://formacion.4eixos.com/tema_1_web_addenda_cgroups/cgroups_xestin_e_utilidades.html).
+1. **Consultar** e **analizar** a documentación sobre [cgroups: grupos de control de procesos](https://prefapp.github.io/formacion/cursos/docker/#/./01_que_e_un_contedor_de_software/09_cgroups_xestion_e_utilidades).
 
 2. **Traballar** cos comandos de xestión de cgroups:
 - Como script de test podes empregar este:
@@ -135,7 +135,7 @@ done
 
 ## Crear os primeiros contedores de software
 
-> Montando un contedor - Empregando [as tecnoloxías que vimos nesta tema (unshare, mount...)](../01_que_e_un_contedor_de_software/08_namespaces_en_profundidade.md) vamos a crear un contedor de software de xeito "artesanal"
+> Montando un contedor - Empregando [as tecnoloxías que vimos nesta tema (unshare, mount...)](https://prefapp.github.io/formacion/cursos/docker/#/./01_que_e_un_contedor_de_software/08_namespaces_en_profundidaded) vamos a crear un contedor de software de xeito "artesanal"
 
 O contedor ten que reunir as seguintes características:
 
@@ -143,7 +143,7 @@ O contedor ten que reunir as seguintes características:
 
 - O contedor ten que montar este [sistema de ficheiros](https://github.com/ericchiang/containers-from-scratch/releases/download/v0.1.0/rootfs.tar.gz).
 
-- Ten que estás illado nos seguintes [namespaces](../01_que_e_un_contedor_de_software/08_namespaces_en_profundidade.md): (pids, mounts, UTS, network, ipc)
+- Ten que estás illado nos seguintes [namespaces](https://prefapp.github.io/formacion/cursos/docker/#/./01_que_e_un_contedor_de_software/08_namespaces_en_profundidade): (pids, mounts, UTS, network, ipc)
 
 - Ten que ter montado un /proc propio
 
@@ -156,7 +156,7 @@ O contedor ten que reunir as seguintes características:
  - Como probar que o UTS está realmente illado?
  - Como podemos saber cal é o proceso init do contedor?
  - Como lle daríamos conectividade ó exterior ó contedor?  Pista ([veth](http://man7.org/linux/man-pages/man4/veth.4.html)).
- - Sabendo o que son os [cgroups](../01_que_e_un_contedor_de_software/09_cgroups_xestion_e_utilidades.md), limita a memoria do contedor a ```512 MB```.
+ - Sabendo o que son os [cgroups](https://prefapp.github.io/formacion/cursos/docker/#/./01_que_e_un_contedor_de_software/09_cgroups_xestion_e_utilidades), limita a memoria do contedor a ```512 MB```.
 
 ---
 

--- a/cursos/docker/00_actividades/02_modulo_2.md
+++ b/cursos/docker/00_actividades/02_modulo_2.md
@@ -35,7 +35,7 @@ Obviamente, queremos facelo dentro dun contedor, e que monte **unha distro CentO
 Tal e como viramos na práctica do módulo 1 (construindo o noso contedor) poderíamos seguir eses pasos para face-lo traballo:
 
 - Descargar un sistema de ficheiros de CentOS.
-- Montar un contedor con unshare, limitando os [namespaces](https://prefapp.github.io/formacion/docker/#/01_que_e_un_contedor_de_software/08_namespaces_en_profundidade), facer un chroot a onde está o sistema de ficheiros descargado...
+- Montar un contedor con unshare, limitando os [namespaces](https://prefapp.github.io/formacion/cursos/docker/#/./01_que_e_un_contedor_de_software/08_namespaces_en_profundidade), facer un chroot a onde está o sistema de ficheiros descargado...
 - ...
 
 pero agora xa podemos empregar Docker para facelo. Con Docker, básicamente, temos que seguir a mesma receta, pero, afortunadamente, todo iso está automatizado dentro das súas [utilidades](https://docs.docker.com/engine/reference/commandline/run/).
@@ -130,11 +130,11 @@ docker restart <nome_container_php>
 3.2: ¿Como poderíamos comprobar o funcionamento do código ca versión 5.6 de php? ¿e ca última versión 7.3? ¿Podemos ter as 3 versións da aplicación  funcionando á vez, cada unha no seu porto (8080,8081,8082)?
 ¿Como limitaríamos o consumo de recursos no anfitrión (50 MB de memoria, 50% dunha cpu) para os 3 contedores cas diferentes versións da aplicación?
 
-4. Agora vamos a **probar a aplicación** de [portainer](https://prefapp.github.io/formacion/docker/#/./02_docker/10_portainer) e ver os containers correndo na máquina virtual, de maneira gráfica dende un navegador.
+4. Agora vamos a **probar a aplicación** de [portainer](https://prefapp.github.io/formacion/cursos/docker/#/./02_docker/10_portainer) e ver os containers correndo na máquina virtual, de maneira gráfica dende un navegador.
 
-4.1 Para isto seguir os pasos indicados nos [contidos](https://prefapp.github.io/formacion/docker/#/./02_docker/10_portainer) do curso.
+4.1 Para isto seguir os pasos indicados nos [contidos](https://prefapp.github.io/formacion/cursos/docker/#/./02_docker/10_portainer) do curso.
 
-4.2 Apagar todos os contedores dende [portainer](https://prefapp.github.io/formacion/docker/#/./02_docker/10_portainer). Antes de esto descargar unha copia sql da base de datos, dende o phpmyadmin.
+4.2 Apagar todos os contedores dende [portainer](https://prefapp.github.io/formacion/cursos/docker/#/./02_docker/10_portainer). Antes de esto descargar unha copia sql da base de datos, dende o phpmyadmin.
 
 **Evidencias de adquición de desempeños**: Pasos 1 ao 4 correctamente realizados segundo estes...
 
@@ -150,7 +150,7 @@ Se vos resulta máis sinxelo podedes remitirnos o repositorio de código de gith
  - Lanzar a aplicación php desenvolta, conectada co contedor mysql do exercicio anterior.
  - Lanzar novas versións da aplicación php desenvolta, cas versión 5.6 e 7.3 de php.
    * Limitadas a consumir 50MB de RAM e o 50% de 1 cpu
- - Lanzar o contedor de [portainer](https://prefapp.github.io/formacion/docker/#/./02_docker/10_portainer) e listar todos os contedores executándose na maquina docker
+ - Lanzar o contedor de [portainer](https://prefapp.github.io/formacion/cursos/docker/#/./02_docker/10_portainer) e listar todos os contedores executándose na maquina docker
 
 Se vos resulta máis sinxelo podedes remitirnos os json de [asciinema](https://asciinema.org/) con estos comandos.
 

--- a/cursos/docker/00_actividades/03_modulo_3.md
+++ b/cursos/docker/00_actividades/03_modulo_3.md
@@ -6,7 +6,7 @@
 
 \**Nota - Antes de realizar a tarefa le atentamente as **instrucións**, os **indicadores de logro** e os **criterios de corrección** que de seguido se detallan.
 
-1. **Consultar** e **analizar** a documentación sobre  [imaxes e contedores](https://formacion.4eixos.com/tema_3_web/index.html).
+1. **Consultar** e **analizar** a documentación sobre  [imaxes e contedores](https://prefapp.github.io/formacion/cursos/docker/#/./03_xestion_de_imaxes_e_contedores/01_obxectivos).
 2. **Crear** unha conta en [Dockerhub](https://hub.docker.com/). A pesares de que non é necesario estar rexistrado no Dockerhub para poder descargar imaxes, sí que imos precisar ter conta para poder subir as nosas imaxes.
 
 Cree unha conta no dockerhub. É gratuito e a imos empregar para subir os nosos traballos e distribuilos.
@@ -45,7 +45,7 @@ Para realizar esta tarefa, compre crear un documento onde iremos rexistrando os 
 
 Pasos:
 
-1. **Consultar** e **analizar** a documentación sobre [imaxes e contedores](https://formacion.4eixos.com/tema_3_web/index.html).
+1. **Consultar** e **analizar** a documentación sobre [imaxes e contedores](https://prefapp.github.io/formacion/cursos/docker/#/./03_xestion_de_imaxes_e_contedores/01_obxectivos).
 2. **Investigar** e **compilar** as opcións do comando docker images
  1. O comando expón unha axuda (docker images --help) ou pódese consultar na [documentación oficial](https://docs.docker.com/engine/reference/commandline/images/).
  2. No pdf, crear unha sección "1" onde se expoñerán as opcións do comando docker images e un resumo sobre a súa función.

--- a/cursos/kubernetes/00_actividades/02_modulo_2.md
+++ b/cursos/kubernetes/00_actividades/02_modulo_2.md
@@ -2,7 +2,7 @@
 
 ## Instalando Kubernetes na nosa máquina local
 
-Como falaramos na parte [expositiva](../02_kubernetes/01_que_e_kubernetes.md), Kubernetes pódese instalar de moitos xeitos e ten vocación de correr en diferentes contornas (cloud, on premise, bare-metal...) e, tamén, na nosa máquina local.
+Como falaramos na parte [expositiva](https://prefapp.github.io/formacion/cursos/kubernetes/#/./02_kubernetes/01_que_e_kubernetes), Kubernetes pódese instalar de moitos xeitos e ten vocación de correr en diferentes contornas (cloud, on premise, bare-metal...) e, tamén, na nosa máquina local.
 
 No curso, recomendamos [microk8s](https://microk8s.io/) que é un excelente traballo da xente de Canonical e que nos permite, a través de [snap](https://snapcraft.io/), instalar e xestionar un minuclúster de Kubernetes (realmente o "master" e o "nodo" son virtuais e todo corre na nosa Ubuntu local) para facer as prácticas, desenvolver aplicacións, etc...
 
@@ -58,7 +58,7 @@ E teríamos o sistema detido.
 
 ### c) Habilitando os servizos
 
-Por defecto, microk8s instálase sen o servizo de dns, fundamental para traballar con [servizos](../02_kubernetes/05_arquitectura_kubernetes_service.md).
+Por defecto, microk8s instálase sen o servizo de dns, fundamental para traballar con [servizos](https://prefapp.github.io/formacion/cursos/kubernetes/#/./02_kubernetes/05_arquitectura_kubernetes_service).
 
 Para habilitalo, basta con facer:
 
@@ -156,7 +156,7 @@ O dashboard escoita no porto 443 e vai por https. O certificado é autofirmado p
 
 Nesta tarefa imos revisar os conceptos sobre Kubernetes (k8s).
 
-Compre ler a [documentación](../02_kubernetes/) que temos no módulo.
+Compre ler a [documentación](https://prefapp.github.io/formacion/cursos/kubernetes/#/./02_kubernetes/01_que_e_kubernetes) que temos no módulo.
 
 Esta tarefa non ten entrega.
 
@@ -192,7 +192,7 @@ Imos a montar unha sinxela aplicación escrita en nodejs que fai o seguinte:
 
 ### a) Despregue en pod
 
-Para comezar, imos despregar a nosa aplicación nun [pod](../02_kubernetes/03_arquitectura_kubernetes_pod.md):
+Para comezar, imos despregar a nosa aplicación nun [pod](https://prefapp.github.io/formacion/cursos/kubernetes/#/./02_kubernetes/03_arquitectura_kubernetes_pod):
 - A imaxe a montar será "frmadem/catro-eixos-k8s-ej1", co tag "v1", esto é: "frmadem/catro-eixos-k8s-ej1:v1".
 - O pod terá como nome "pod-practica-1".
 - Executará como comando "npm" "run" "iniciar".
@@ -219,7 +219,7 @@ Vemos a **versión** da aplicación, o **hostname** (o nome do pod onde está a 
 
 ### b) Montando un deploy
 
-Se queremos correr a nosa aplicación con réplicas e control das mesmas compre que empreguemos un [deploy](../02_kubernetes/04_arquitectura_kubernetes_deployment.md).
+Se queremos correr a nosa aplicación con réplicas e control das mesmas compre que empreguemos un [deploy](https://prefapp.github.io/formacion/cursos/kubernetes/#/./02_kubernetes/04_arquitectura_kubernetes_deployment).
 
 Para montar o noso despregue temos que cumprir unha serie de requisitos:
 - O despregue terá como nome "**despregue-practica-1**".
@@ -246,7 +246,7 @@ Agora, temos un deploy que ten réplicas e queremos que poida dar resposta calqu
 
 Para iso, compre montar un servizo.
 
-O [servizo](./02_kubernetes/05_arquitectura_kubernetes_service.md) que expón o noso deploy ten que ter novamente unha serie de características:
+O [servizo](https://prefapp.github.io/formacion/cursos/kubernetes/#/./02_kubernetes/05_arquitectura_kubernetes_service) que expón o noso deploy ten que ter novamente unha serie de características:
 - O servizo terá como nome "**servizo-practica-1**".
 - O porto do servizo será o 80
 - Conectará cos pods no porto 8080.

--- a/cursos/kubernetes/00_actividades/03_modulo_3.md
+++ b/cursos/kubernetes/00_actividades/03_modulo_3.md
@@ -1,8 +1,8 @@
 # Mellorando a nosa aplicación.
 
-Para facer esta tarefa, primeiro compre ler a documentación sobre "[avanzando en Kubernetes](https://formacion.4eixos.com/k8s/tema3/)".
+Para facer esta tarefa, primeiro compre ler a documentación sobre "[avanzando en Kubernetes](https://prefapp.github.io/formacion/cursos/kubernetes/#/./03_configuracion/01_Configuracions_en_Kubernetes)".
 
-Imos mellorar o noso despregue de aplicación da tarefa [2.3](https://formacion.4eixos.com/k8s/actividades/2/correndo_a_nosa_primeira_aplicacin_en_kubernetes.html).
+Imos mellorar o noso despregue de aplicación da tarefa [2.3](https://prefapp.github.io/formacion/cursos/kubernetes/#/./00_actividades/02_modulo_2?id=correndo-a-nosa-primeira-aplicación-en-kubernetes).
 
 Polo tanto, é necesario ter rematada esa tarefa antes de acometer a de este módulo.
 
@@ -148,7 +148,7 @@ ___
 
 Imos correr a nosa aplicación nun clúster real de Kubernetes.
 
-Para facer isto compre revisar a documentación [sobre usuarios e roles](https://formacion.4eixos.com/k8s/tema_3_addenda/index.html).
+Para facer isto compre revisar a documentación [sobre usuarios e roles](https://prefapp.github.io/formacion/cursos/kubernetes/#/./03_configuracion/01_Configuracions_en_Kubernetes).
 
 O administrador do clúster vainos pedir unha serie de elementos:
 * Un certificado xerado por nós para poder traballar contra a API do clúster.
@@ -168,7 +168,7 @@ Esos obxectos e o certificado **deberán ir nun tar** que remitiremos ó adminis
 
 ## A) Xerar as nosas credenciais
 
-Para xerar as nosas credenciais compre seguir esta [guía](https://formacion.4eixos.com/k8s/guias/xeracion-certificados/).
+Para xerar as nosas credenciais compre seguir esta [guía](https://prefapp.github.io/formacion/cursos/kubernetes/#/./03_configuracion/00_Guia_cert).
 
 Copiamos á nosa ruta de tar o certificado .csr (por exemplo f.maseda.csr).
 
@@ -282,7 +282,7 @@ Partindo da imaxe fonte:
 * Lanzar o servidor web.
 
 Pasos:
-1. **Consultar** e **analizar** a documentación sobre [imaxes e contedores](https://formacion.4eixos.com/tema_3_web/index.html).
+1. **Consultar** e **analizar** a documentación sobre imaxes e contedores.
 2. Nun pdf, os capturas de pantalla de todo o necesario para:
 	2.1. **Crear unha imaxe** a partir da oficial de registry co seguinte nome: #nome-registry, sendo #nome o nome de pila do alumno.
 	2.2. **Lanzar unha instancia** do registry coa imaxe creada, esta instancia ten que reuni-los seguintes requisitos:

--- a/cursos/kubernetes/00_solucions/01_solucion/01_solucion.md
+++ b/cursos/kubernetes/00_solucions/01_solucion/01_solucion.md
@@ -1,6 +1,6 @@
 # Ejercicio Kubernetes 2
 
-[link](https://formacion.4eixos.com/k8s/actividades/2/correndo_a_nosa_primeira_aplicacin_en_kubernetes.html) al ejercicio.
+[link](https://prefapp.github.io/formacion/cursos/kubernetes/#/./00_actividades/02_modulo_2?id=correndo-a-nosa-primeira-aplicación-en-kubernetes) al ejercicio.
 
 Cuando despliego el Deploy y el servicio hago un curl a la direccion ip del serivicio y no devuelve nada.
 

--- a/cursos/kubernetes/00_solucions/02_solucion/solucion.md
+++ b/cursos/kubernetes/00_solucions/02_solucion/solucion.md
@@ -1,6 +1,6 @@
 # Ejercicio Kubernetes 2
 
-[link](https://formacion.4eixos.com/k8s/actividades/2/correndo_a_nosa_primeira_aplicacin_en_kubernetes.html) al ejercicio.
+[link](https://prefapp.github.io/formacion/cursos/kubernetes/#/./00_actividades/02_modulo_2?id=correndo-a-nosa-primeira-aplicación-en-kubernetes) al ejercicio.
 
 
 COMANDOS EJECUCION

--- a/cursos/kubernetes/03_configuracion/00_Guia_cert.md
+++ b/cursos/kubernetes/03_configuracion/00_Guia_cert.md
@@ -1,0 +1,24 @@
+#Xeración de certificado
+
+Para xerar un certificado imos empregar [cfssl](https://cfssl.org/).
+
+```shell
+# Baixamos o software
+
+mkdir ~/bin
+curl -s -L -o ~/bin/cfssl https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+curl -s -L -o ~/bin/cfssljson https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+chmod +x ~/bin/{cfssl,cfssljson}
+export PATH=$PATH:~/bin
+```
+
+ Imos empregar un json para xerar o certificado, nunha ruta:
+```shell
+echo '{"CN":"<inicial_nome.apelido>","hosts":[""],"key":{"algo":"rsa","size":2048}}' \
+| cfssl genkey  - | cfssljson -bare <inicial_nome.apelido>
+
+# obteremos dous ficheiros
+ls
+
+<inicial_nome.apelido>.csr <inicial_nome.apelido>-key.pem
+```


### PR DESCRIPTION
Amañando os links que apuntaban a 4eixos dime conta de que todos os links internos estaban mal así que fun un por un revisando todos. Intentei poñelos como links relativos pero deixaba de funcionar a barra de navegación (si se cambia o nome do repo van caer todos).
Vin un link que apuntaba a 4eixos "Xeración de certificado", non existía, así que creei a guía dentro deste repo.
